### PR TITLE
fix: menu icon do not show

### DIFF
--- a/src/managers/menu.ts
+++ b/src/managers/menu.ts
@@ -109,7 +109,11 @@ export class MenuManager extends ManagerTool {
         children: [],
       };
       if (menuitemOption.icon) {
-        elementOption.attributes!["class"] += " menuitem-iconic";
+        if (menuitemOption.tag === "menu") {
+          elementOption.attributes!["class"] += " menu-iconic";
+        } else {
+          elementOption.attributes!["class"] += " menuitem-iconic";
+        }
         elementOption.styles![
           "list-style-image" as any
         ] = `url(${menuitemOption.icon})`;


### PR DESCRIPTION
before

![before](https://github.com/windingwind/zotero-plugin-toolkit/assets/44738481/5d42f4bc-6ab9-4d4b-97a5-f34084a30a6f)

after

![after](https://github.com/windingwind/zotero-plugin-toolkit/assets/44738481/57f92c7d-c223-4dd4-ba83-c207c0a2ec34)
