### PR TITLE
Update prompt.ts

### DIFF
--- a/src/managers/prompt.ts
+++ b/src/managers/prompt.ts
@@ -208,9 +208,11 @@ export class Prompt {
       /**
        * Filter out anonymous commands
        */
-      if (!command.name || (command.when && !command.when())) {
-        continue;
-      }
+      try {
+        if (!command.name || (command.when && !command.when())) {
+          continue;
+        }
+      } catch { continue }
       commandsContainer.appendChild(this.createCommandNode(command));
     }
   }


### PR DESCRIPTION
Prevents subsequent commands from not being displayed due to "command.when function errors".

![image](https://github.com/windingwind/zotero-plugin-toolkit/assets/51939531/5c6d8c15-31a1-49a3-b1b3-3af74df69af6)

