### PR TITLE
[TAS-21] fixed menuitem's icon doesn't display on macOS

### DIFF
--- a/src/managers/menu.ts
+++ b/src/managers/menu.ts
@@ -109,11 +109,6 @@ export class MenuManager extends ManagerTool {
         children: [],
       };
       if (menuitemOption.icon) {
-        if (menuitemOption.tag === "menu") {
-          elementOption.attributes!["class"] += " menu-iconic";
-        } else {
-          elementOption.attributes!["class"] += " menuitem-iconic";
-        }
         elementOption.styles![
           "list-style-image" as any
         ] = `url(${menuitemOption.icon})`;


### PR DESCRIPTION
No more need `class="menu-iconic"` and `class="menuitem-iconic"`.
Please check it work also well on Windows as I have only verified on my Apple Silicon M1 MacBook Pro with macOS 13.5.

<img width="276" alt="image" src="https://github.com/windingwind/zotero-plugin-toolkit/assets/10293675/aa74bfb8-5cba-410f-9d33-535105935d47">
