### PR TITLE
add default param 'type' for func `addText` in helpers/clipboard.

### DIFF
--- a/src/helpers/clipboard.ts
+++ b/src/helpers/clipboard.ts
@@ -39,7 +39,7 @@ export class ClipboardHelper {
     this.transferable.init(null);
   }
 
-  public addText(source: string, type: "text/html" | "text/unicode") {
+  public addText(source: string, type: "text/html" | "text/unicode" = "text/unicode") {
     const str = Components.classes[
       "@mozilla.org/supports-string;1"
     ].createInstance(Components.interfaces.nsISupportsString);


### PR DESCRIPTION
> 默认复制为纯文本，使参数列表格式与其他函数保持对齐
Copy as plain text by default, so that the form of param list could be aligned with other functions.