### PR TITLE
Update menu.ts

### DIFF
--- a/src/managers/menu.ts
+++ b/src/managers/menu.ts
@@ -149,6 +149,19 @@ export class MenuManager extends ManagerTool {
           }
         });
       }
+      if (menuitemOption.isDisabled) {
+        popup?.addEventListener("popupshowing", (ev: Event) => {
+          const disabled = menuitemOption.isDisabled!(menuItem as any, ev);
+          if (typeof disabled === "undefined") {
+            return;
+          }
+          if (disabled) {
+            menuItem.setAttribute("disabled", "true");
+          } else {
+            menuItem.removeAttribute("disabled");
+          }
+        });
+      }
       if (menuitemOption.tag === "menu") {
         const subPopup = this.ui.createElement(doc, "menupopup", {
           id: menuitemOption.popupId,
@@ -162,14 +175,18 @@ export class MenuManager extends ManagerTool {
       return menuItem;
     };
     const topMenuItem = genMenuElement(options);
-    if (!anchorElement) {
-      anchorElement = (
-        insertPosition === "after"
-          ? popup.lastElementChild
-          : popup.firstElementChild
-      ) as XUL.Element;
+    if (popup.childElementCount) {
+      if (!anchorElement) {
+        anchorElement = (
+          insertPosition === "after"
+            ? popup.lastElementChild
+            : popup.firstElementChild
+        ) as XUL.Element;
+      }
+      anchorElement[insertPosition](topMenuItem);
+    } else {
+      popup.appendChild(topMenuItem);
     }
-    anchorElement[insertPosition](topMenuItem);
   }
 
   unregister(menuId: string) {
@@ -197,6 +214,8 @@ type MenuitemTagDependentOptions =
       tag: "menuitem";
       /* return true to show and false to hide current element */
       getVisibility?: (elem: XUL.MenuItem, ev: Event) => boolean | undefined;
+      /* return true to disable and false to enable current element */
+      isDisabled?: (elem: XUL.MenuItem, ev: Event) => boolean | undefined;
       type?: "" | "checkbox" | "radio";
       checked?: boolean;
     }
@@ -204,6 +223,8 @@ type MenuitemTagDependentOptions =
       tag: "menu";
       /* return true to show and false to hide current element */
       getVisibility?: (elem: XUL.Menu, ev: Event) => boolean | undefined;
+      /* return true to disable and false to enable current element */
+      isDisabled?: (elem: XUL.Menu, ev: Event) => boolean | undefined;
       /* Attributes below are used when type === "menu" */
       popupId?: string;
       onpopupshowing?: string;
@@ -217,6 +238,11 @@ type MenuitemTagDependentOptions =
       tag: "menuseparator";
       /* return true to show and false to hide current element */
       getVisibility?: (
+        elem: XUL.MenuSeparator,
+        ev: Event,
+      ) => boolean | undefined;
+      /* return true to disable and false to enable current element */
+      isDisabled?: (
         elem: XUL.MenuSeparator,
         ev: Event,
       ) => boolean | undefined;

--- a/src/managers/menu.ts
+++ b/src/managers/menu.ts
@@ -171,10 +171,10 @@ export class MenuManager extends ManagerTool {
       if (
         (menuitemOption.tag === "menuitem" ||
           menuitemOption.tag === "menuseparator") &&
-        menuitemOption.onPopupShowing
+        menuitemOption.onShowing
       ) {
         popup?.addEventListener("popupshowing", (ev: Event) => {
-          menuitemOption.onPopupShowing!(menuItem as any, ev);
+          menuitemOption.onShowing!(menuItem as any, ev);
         });
       }
       if (menuitemOption.tag === "menu") {
@@ -245,7 +245,7 @@ type MenuitemTagDependentOptions =
       /**
        * Fired when the containing menu popup is shown
        */
-      onPopupShowing?: (elem: XUL.MenuItem, event: Event) => any;
+      onShowing?: (elem: XUL.MenuItem, event: Event) => any;
       type?: "" | "checkbox" | "radio";
       checked?: boolean;
     }
@@ -268,6 +268,9 @@ type MenuitemTagDependentOptions =
       isDisabled?: (elem: XUL.Menu, ev: Event) => boolean | undefined;
       /* Attributes below are used when type === "menu" */
       popupId?: string;
+      /**
+       * Fired when the containing menu popup is shown. Consider using `onShowing` instead.
+       */
       onpopupshowing?: string;
       children?: Array<MenuitemOptions>;
       /**
@@ -298,7 +301,7 @@ type MenuitemTagDependentOptions =
       /**
        * Fired when the containing menu popup is shown
        */
-      onPopupShowing?: (elem: XUL.MenuSeparator, event: Event) => any;
+      onShowing?: (elem: XUL.MenuSeparator, event: Event) => any;
     };
 
 interface MenuitemCommonOptions {


### PR DESCRIPTION
- Adds an optional event handler to determine whether the item, while shown, is disabled
- Adds support for registering an element when the popup has no children (for instance, was created with ztoolkit.UI.createElement() just before);

Fixes #70 