### PR TITLE
Fix function name spelling: waitUtilAsync → waitUntilAsync

### DIFF
--- a/src/utils/wait.ts
+++ b/src/utils/wait.ts
@@ -19,6 +19,8 @@ export function waitUntil(
   }, interval);
 }
 
+// For compatibility
+export const waitUtilAsync = waitUntilAsync;
 export function waitUntilAsync(
   condition: () => boolean,
   interval = 100,

--- a/src/utils/wait.ts
+++ b/src/utils/wait.ts
@@ -19,7 +19,7 @@ export function waitUntil(
   }, interval);
 }
 
-export function waitUtilAsync(
+export function waitUntilAsync(
   condition: () => boolean,
   interval = 100,
   timeout = 10000,


### PR DESCRIPTION
Fix function name spelling: waitUtilAsync → waitUntilAsync