### PR TITLE
fix: allow the icon URI of processWindow to not start with `chrome://`

### DIFF
--- a/src/helpers/progressWindow.ts
+++ b/src/helpers/progressWindow.ts
@@ -171,11 +171,7 @@ export class ProgressWindowHelper {
       this.lines.forEach((line) => {
         const box = (line as any)._image as XUL.Box;
         const icon = box.dataset.itemType;
-        if (
-          icon &&
-          icon.startsWith("chrome://") &&
-          !box.style.backgroundImage.includes("progress_arcs")
-        ) {
+        if (icon && !box.style.backgroundImage.includes("progress_arcs")) {
           box.style.backgroundImage = `url(${box.dataset.itemType})`;
         }
       });


### PR DESCRIPTION
After testing, the path starting with rootURI is also available.