### PR TITLE
chore(deps): fix stub types warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,11 +51,11 @@
     "@microsoft/api-extractor": "^7.52.8",
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.3.7",
-    "@types/react-intl": "^3.0.0",
     "eslint": "^9.28.0",
     "husky": "^9.1.7",
     "lint-staged": "^15.5.2",
     "prettier": "^3.5.3",
+    "react-intl": "^7.1.11",
     "release-it": "^17.11.0",
     "typescript": "^5.8.3",
     "zotero-types": ">=4.0.0"


### PR DESCRIPTION
`@types/react-intl` is a stub types definition. `react-intl` provides its own type definitions, so we do not need this installed.