### PR TITLE
fix(keyboard): KeyModifier string parser no longer strips hyphen from key

### DIFF
--- a/src/managers/keyboard.ts
+++ b/src/managers/keyboard.ts
@@ -187,9 +187,9 @@ export class KeyModifier implements KeyModifierStatus {
       this.control = raw.includes("control");
       this.meta = raw.includes("meta");
       this.alt = raw.includes("alt");
-      // Remove all modifiers, space, comma, and dash
+      // Remove all modifiers, space, and comma
       this.key = raw
-        .replace(/(accel|shift|control|meta|alt|[ ,\-])/g, "")
+        .replace(/(accel|shift|control|meta|alt|[ ,])/g, "")
         .toLocaleLowerCase();
       if (!this.key && (raw.includes(",,") || raw === ",")) {
         // If there are two consecutive commas, it means the key is a comma


### PR DESCRIPTION
## Problem

`new KeyModifier("accel,-")` results in `km.key === ""` instead of `km.key === "-"`.

The string constructor at `src/managers/keyboard.ts:191` strips characters with regex `[ ,\-]`. The `-` was intended as a separator for hyphen-separated input formats (e.g. `Ctrl-Shift-B`), but the canonical format used throughout `KeyModifier` is comma-separated (from `getRaw()`).

## Impact

Any key that contains or equals a hyphen (e.g. `-`, `=`, or other special characters that might be affected) is lost when constructing from raw strings. This affects downstream plugins that use `KeyModifier` for shortcut display and comparison.

### Reproduction

```ts
const km = new KeyModifier("accel,-");
console.log(km.key); // "" — should be "-"
```

## Fix

Remove `-` from the separator character class in the regex. The comma key is still handled correctly by the existing fallback on line 194.

> The hyphen-separated format (e.g. `Ctrl-Shift-B`) was never used internally by any part of the toolkit, so this change does not break existing functionality.